### PR TITLE
Updated MulticloudOperatorsFoundation (ManagedClusterView setup) readme

### DIFF
--- a/registration-operator-mcf.diff
+++ b/registration-operator-mcf.diff
@@ -1,0 +1,41 @@
+diff --git a/Makefile b/Makefile
+index cb477b4..c3f7289 100644
+--- a/Makefile
++++ b/Makefile
+@@ -101,7 +101,7 @@ install-olm: ensure-operator-sdk
+ 	$(KUBECTL) get ns open-cluster-management ; if [ $$? -ne 0 ] ; then $(KUBECTL) create ns open-cluster-management ; fi
+ 
+ install-olm-kind: ensure-operator-sdk
+-	$(KUBECTL) config use-context kind-$(MANAGED_CLUSTER)
++	$(KUBECTL) config use-context $(MANAGED_CLUSTER)
+ 	$(KUBECTL) get crds | grep clusterserviceversion ; if [ $$? -ne 0 ] ; then $(OPERATOR_SDK) olm install --version $(OLM_VERSION); fi
+ 	$(KUBECTL) get ns open-cluster-management ; if [ $$? -ne 0 ] ; then $(KUBECTL) create ns open-cluster-management ; fi
+ 
+@@ -127,15 +127,15 @@ bootstrap-secret: cluster-ip
+ 	cp $(KUBECONFIG) dev-kubeconfig
+ 	$(KUBECTL) config use-context $(KLUSTERLET_KUBECONFIG_CONTEXT)
+ 	$(KUBECTL) get ns open-cluster-management-agent; if [ $$? -ne 0 ] ; then $(KUBECTL) create ns open-cluster-management-agent; fi
+-	$(KUBECTL) config set clusters.kind-$(MANAGED_CLUSTER).server https://$(CLUSTER_IP) --kubeconfig dev-kubeconfig
++	$(KUBECTL) config set clusters.$(MANAGED_CLUSTER).server https://$(CLUSTER_IP) --kubeconfig dev-kubeconfig
+ 	$(KUBECTL) delete secret bootstrap-hub-kubeconfig -n open-cluster-management-agent --ignore-not-found
+ 	$(KUBECTL) create secret generic bootstrap-hub-kubeconfig --from-file=kubeconfig=dev-kubeconfig -n open-cluster-management-agent
+ 
+ bootstrap-secret-kind: cluster-hub-ip-kind
+ 	cp $(HUB_KIND_KUBECONFIG) dev-kubeconfig
+-	$(KUBECTL) config use-context kind-$(MANAGED_CLUSTER)
++	$(KUBECTL) config use-context $(MANAGED_CLUSTER)
+ 	$(KUBECTL) get ns open-cluster-management-agent; if [ $$? -ne 0 ] ; then $(KUBECTL) create ns open-cluster-management-agent; fi
+-	$(KUBECTL) --kubeconfig dev-kubeconfig config set clusters.kind-$(HUB_CLUSTER).server https://$(CLUSTER_IP_KIND)
++	$(KUBECTL) --kubeconfig dev-kubeconfig config set clusters.$(HUB_CLUSTER).server https://$(CLUSTER_IP_KIND)
+ 	$(KUBECTL) delete secret bootstrap-hub-kubeconfig -n open-cluster-management-agent --ignore-not-found
+ 	$(KUBECTL) create secret generic bootstrap-hub-kubeconfig --from-file=kubeconfig=dev-kubeconfig -n open-cluster-management-agent
+ 
+@@ -161,7 +161,7 @@ apply-spoke-cr:
+ 	$(SED_CMD) -e "s,quay.io/open-cluster-management/registration,$(REGISTRATION_IMAGE)," -e "s,quay.io/open-cluster-management/work,$(WORK_IMAGE)," deploy/klusterlet/config/samples/operator_open-cluster-management_klusterlets.cr.yaml | $(KUBECTL) apply -f -
+ 
+ apply-spoke-cr-kind:
+-	$(KUBECTL) config use-context kind-$(MANAGED_CLUSTER)
++	$(KUBECTL) config use-context $(MANAGED_CLUSTER)
+ 	$(KUBECTL) apply -f deploy/klusterlet/config/samples/operator_open-cluster-management_klusterlets.cr.yaml
+ 
+ clean-spoke: ensure-operator-sdk


### PR DESCRIPTION
By following instructions in MulticloudOperatorsFoundation.md, users should be able to create a hub and managedcluster that are connected and support ManagedClusterView. This setup has changed since the multicloud-operators-foundation project has changed to fix some bugs, which altered the setup itself. Both Minikube and Kind setups are supported and described.

These instructions were based off the following code versions: 

1. [multicloud-operators-foundation](https://github.com/open-cluster-management/multicloud-operators-foundation) commit  `f8deb294e1e142ba2ca63695d27f5ab3c138eeb3` from 5/10/2021 
2. [registration-operator](https://github.com/open-cluster-management/registration-operator) commit `813609193cd75487a9451c86ccd66e9e3e7e4c2b` from 5/11/2021 